### PR TITLE
CI: Check only against maintained Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: ruby
+
 rvm:
-  - 2.3.0
-  - 1.9.3
-  - jruby-19mode
+  - "2.7"
+  - "2.6"
+  - "2.5"
   - ruby-head
   - jruby-head
-
-# Workaround for Travis + Bundler issues. If this ticket has been resolved, maybe we can remove the workaround.
-# https://github.com/travis-ci/travis-ci/issues/3531
-before_install:
-  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,10 @@ rvm:
   - "2.7"
   - "2.6"
   - "2.5"
-  - ruby-head
-  - jruby-head
+  - "ruby-head"
+  - "jruby-head"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a DebiTech payment library extracted from production code.
 
 You can use this to do subscription payments without needing to handle any credit card information yourself.
 
-If you want something more low level, check the [debitech_soap](https://github.com/joakimk/debitech_soap) gem, which this library uses for API access.
+If you want something more low-level, check the [debitech_soap](https://github.com/joakimk/debitech_soap) gem, which this library uses for API access.
 
 Setting up payments using DebiTech (one of the two payment systems run by DIBS) is not trivial,
 but it seems there are not many good options in Sweden yet. Atleast using this you don't need to


### PR DESCRIPTION
This PR drops the old and unused Ruby versions from the CI matrix. See [Ruby maintenance branches for more information](https://www.ruby-lang.org/en/downloads/branches/).

This PR also **reactivated the Travis CI** for this.

With this PR, we ~are configuration-free in the~ have fewer CI settings.